### PR TITLE
Fix cask name

### DIFF
--- a/Casks/companion.rb
+++ b/Casks/companion.rb
@@ -11,5 +11,5 @@ cask "companion" do
   desc "App for music assistant"
   homepage "https://music-assistant.github.io/"
 
-  app "music-assistant-companion.app"
+  app "Music Assistant Companion.app"
 end


### PR DESCRIPTION
The name of the app was the old version which was kebab case. I've updated it to the newer name with spaces and uppercase letters

Fixes #2 