### PR TITLE
SHA256 checksum mismatch

### DIFF
--- a/Casks/companion.rb
+++ b/Casks/companion.rb
@@ -2,7 +2,7 @@ cask "companion" do
   arch arm: "aarch64", intel: "x64"
 
   version "0.0.74"
-  sha256 arm:   "463ee8245e8a93c569158617e14e76444b0d761c5a6025285c6f368292dfa2a2",
+  sha256 arm:   "a47b47d4ac238c95fe76ae94e0da64505571cc8d0e46726ef96e0ef6c83dcb50",
          intel: "c0b0759f38abc9267720a662c53406b3365ef9893ea9bbb02729037179134ddd"
 
   url "https://github.com/music-assistant/companion/releases/download/v#{version}/Music.Assistant.Companion_#{arch}.app.tar.gz",


### PR DESCRIPTION
❯ brew install music-assistant/tap/companion
==> Upgrading 1 outdated package:
music-assistant/tap/companion 0.0.71 -> 0.0.74
==> Upgrading companion
==> Downloading https://github.com/music-assistant/companion/releases/download/v0.0.74/Music.Assistant.Companion_aarch64.app.tar.gz
Already downloaded: /Users/<user>/Library/Caches/Homebrew/downloads/483b60b86f7648b5a1eaefd4f6672a34293aae2d60bbaec9f2f4f25f43b0cbaf--Music.Assistant.Companion_aarch64.app.tar.gz
==> Purging files for version 0.0.74 of Cask companion
Error: music-assistant/tap/companion: SHA256 mismatch
Expected: 463ee8245e8a93c569158617e14e76444b0d761c5a6025285c6f368292dfa2a2
  Actual: a47b47d4ac238c95fe76ae94e0da64505571cc8d0e46726ef96e0ef6c83dcb50
    File: /Users/<user>/Library/Caches/Homebrew/downloads/483b60b86f7648b5a1eaefd4f6672a34293aae2d60bbaec9f2f4f25f43b0cbaf--Music.Assistant.Companion_aarch64.app.tar.gz
To retry an incomplete download, remove the file above.
